### PR TITLE
Fix workflow: run module directly instead of script entry point

### DIFF
--- a/.github/workflows/update-dataset.yml
+++ b/.github/workflows/update-dataset.yml
@@ -36,7 +36,7 @@ jobs:
         run: uv sync
 
       - name: Run dataset downloader
-        run: uv run moltbook-download
+        run: uv run python -m moltbook_data.downloader
 
       - name: Check for changes
         id: changes


### PR DESCRIPTION
uv sync doesn't install the package itself as editable without a build-system section. Use `python -m moltbook_data.downloader` instead.

https://claude.ai/code/session_01J5BFNtH5MTKZNL2e145KbR